### PR TITLE
remove BLR. Bangalore can use the Singapore mirror.

### DIFF
--- a/mirrors
+++ b/mirrors
@@ -10,7 +10,6 @@ England (London)	http://lon.mirror.splise.net/nomadbsd
 France		https://download.nomadbsd.nosheep.fr
 France		https://elgrande74.net/nomadbsd
 Germany		https://ftp.fau.de/nomadbsd
-India (Bangalore)	http://blr.mirror.splise.net/nomadbsd
 Netherlands	https://nomadbsd.emaus.it
 Singapore (SG)	http://sin.mirror.splise.net/nomadbsd
 Sweden		https://ftpmirror2.infania.net/nomadbsd


### PR DESCRIPTION
Hello Marcel and Lars - I'd like to remove my Bangalore mirror since it is the least used of my mirrors. Singapore is only 40 ms away and it is capable of serving both groups. I'll keep San Francisco, New York, London and Singapore.